### PR TITLE
OPS-59 feat: hrbank ddl 생성

### DIFF
--- a/src/main/resources/hrbank-ddl.sql
+++ b/src/main/resources/hrbank-ddl.sql
@@ -9,7 +9,6 @@ CREATE TABLE files
 );
 
 -- backups
--- CREATE TYPE backup_status AS ENUM ('IN_PROGRESS','COMPLETED','SKIPPED','FAILED');
 CREATE TABLE backups
 (
     id                SERIAL PRIMARY KEY,
@@ -35,7 +34,6 @@ CREATE TABLE departments
 );
 
 -- employees
--- CREATE TYPE employee_status AS ENUM ('ACTIVE','RESIGNED','ON_LEAVE');
 CREATE TABLE employees
 (
     id               SERIAL PRIMARY KEY,
@@ -59,7 +57,6 @@ CREATE TABLE employees
         REFERENCES files (id) ON DELETE CASCADE
 );
 
--- CREATE TYPE change_type AS ENUM ('CREATED', 'UPDATED', 'DELETED');
 CREATE TABLE employee_histories
 (
     id              SERIAL PRIMARY KEY,

--- a/src/main/resources/hrbank-ddl.sql
+++ b/src/main/resources/hrbank-ddl.sql
@@ -9,18 +9,18 @@ CREATE TABLE files
 );
 
 -- backups
-CREATE TYPE backup_status AS ENUM ('IN_PROGRESS','COMPLETED','SKIPPED','FAILED');
+-- CREATE TYPE backup_status AS ENUM ('IN_PROGRESS','COMPLETED','SKIPPED','FAILED');
 CREATE TABLE backups
 (
     id                SERIAL PRIMARY KEY,
-    created_at        TIMESTAMPTZ   NOT NULL,
+    created_at        TIMESTAMPTZ  NOT NULL,
     file_id           INTEGER,
-    started_at        TIMESTAMPTZ   NOT NULL,
+    started_at        TIMESTAMPTZ  NOT NULL,
     ended_at          TIMESTAMPTZ,
-    worker_ip_address VARCHAR(255)  NOT NULL,
-    status            backup_status NOT NULL,
+    worker_ip_address VARCHAR(255) NOT NULL,
+    status            VARCHAR(20)  NOT NULL,
     batch_done_at     TIMESTAMPTZ,
-    CONSTRAINT fk_file FOREIGN KEY (file_id) REFERENCES files (id) ON DELETE SET NULL
+    CONSTRAINT fk_file FOREIGN KEY (file_id) REFERENCES files (id) ON DELETE CASCADE
 );
 
 -- departments
@@ -35,19 +35,19 @@ CREATE TABLE departments
 );
 
 -- employees
-CREATE TYPE employee_status AS ENUM ('ACTIVE','RESIGNED','ON_LEAVE');
+-- CREATE TYPE employee_status AS ENUM ('ACTIVE','RESIGNED','ON_LEAVE');
 CREATE TABLE employees
 (
     id               SERIAL PRIMARY KEY,
-    created_at       TIMESTAMPTZ     NOT NULL,
+    created_at       TIMESTAMPTZ  NOT NULL,
     department_id    INTEGER,
     profile_image_id INTEGER,
-    name             VARCHAR(50)     NOT NULL,
-    email            VARCHAR(100)    NOT NULL,
-    employee_number  VARCHAR(255)    NOT NULL,
+    name             VARCHAR(50)  NOT NULL,
+    email            VARCHAR(100) NOT NULL,
+    employee_number  VARCHAR(255) NOT NULL,
     position         VARCHAR(255),
-    hire_date        TIMESTAMPTZ     NOT NULL,
-    status           employee_status NOT NULL,
+    hire_date        TIMESTAMPTZ  NOT NULL,
+    status           VARCHAR(20)  NOT NULL,
 
     CONSTRAINT employees_email_unique UNIQUE (email),
     CONSTRAINT employees_employee_number_unique UNIQUE (employee_number),
@@ -56,16 +56,15 @@ CREATE TABLE employees
         REFERENCES departments (id) ON DELETE RESTRICT,
 
     CONSTRAINT fk_profiles_employee FOREIGN KEY (profile_image_id)
-        REFERENCES files (id) ON DELETE SET NULL
+        REFERENCES files (id) ON DELETE CASCADE
 );
 
-CREATE TYPE change_type AS ENUM ('CREATED', 'UPDATED', 'DELETED');
-
-CREATE TABLE employee_history
+-- CREATE TYPE change_type AS ENUM ('CREATED', 'UPDATED', 'DELETED');
+CREATE TABLE employee_histories
 (
     id              SERIAL PRIMARY KEY,
     employee_number VARCHAR(50) NOT NULL,
-    type            change_type NOT NULL,
+    type            VARCHAR(20) NOT NULL,
     memo            TEXT,
     logged_at       TIMESTAMPTZ NOT NULL,
     modified_at     TIMESTAMPTZ NOT NULL,

--- a/src/main/resources/hrbank-ddl.sql
+++ b/src/main/resources/hrbank-ddl.sql
@@ -1,0 +1,81 @@
+-- files
+CREATE TABLE files
+(
+    id           SERIAL PRIMARY KEY,
+    name         VARCHAR(255) NOT NULL,
+    content_type VARCHAR(100) NOT NULL,
+    size         BIGINT       NOT NULL,
+    created_at   TIMESTAMPTZ  NOT NULL
+);
+
+-- backups
+CREATE TYPE backup_status AS ENUM ('IN_PROGRESS','COMPLETED','SKIPPED','FAILED');
+CREATE TABLE backups
+(
+    id                SERIAL PRIMARY KEY,
+    created_at        TIMESTAMPTZ   NOT NULL,
+    file_id           INTEGER,
+    started_at        TIMESTAMPTZ   NOT NULL,
+    ended_at          TIMESTAMPTZ,
+    worker_ip_address VARCHAR(255)  NOT NULL,
+    status            backup_status NOT NULL,
+    batch_done_at     TIMESTAMPTZ,
+    CONSTRAINT fk_file FOREIGN KEY (file_id) REFERENCES files (id) ON DELETE SET NULL
+);
+
+-- departments
+CREATE TABLE departments
+(
+    id               SERIAL PRIMARY KEY,
+    created_at       TIMESTAMPTZ  NOT NULL,
+    name             VARCHAR(50)  NOT NULL,
+    description      VARCHAR(255) NOT NULL,
+    established_date TIMESTAMPTZ  NOT NULL,
+    CONSTRAINT departments_name_unique UNIQUE (name)
+);
+
+-- employees
+CREATE TYPE employee_status AS ENUM ('ACTIVE','RESIGNED','ON_LEAVE');
+CREATE TABLE employees
+(
+    id               SERIAL PRIMARY KEY,
+    created_at       TIMESTAMPTZ     NOT NULL,
+    department_id    INTEGER,
+    profile_image_id INTEGER,
+    name             VARCHAR(50)     NOT NULL,
+    email            VARCHAR(100)    NOT NULL,
+    employee_number  VARCHAR(255)    NOT NULL,
+    position         VARCHAR(255),
+    hire_date        TIMESTAMPTZ     NOT NULL,
+    status           employee_status NOT NULL,
+
+    CONSTRAINT employees_email_unique UNIQUE (email),
+    CONSTRAINT employees_employee_number_unique UNIQUE (employee_number),
+
+    CONSTRAINT fk_employees_department FOREIGN KEY (department_id)
+        REFERENCES departments (id) ON DELETE RESTRICT,
+
+    CONSTRAINT fk_profiles_employee FOREIGN KEY (profile_image_id)
+        REFERENCES files (id) ON DELETE SET NULL
+);
+
+CREATE TYPE change_type AS ENUM ('CREATED', 'UPDATED', 'DELETED');
+
+CREATE TABLE employee_history
+(
+    id              SERIAL PRIMARY KEY,
+    employee_number VARCHAR(50) NOT NULL,
+    type            change_type NOT NULL,
+    memo            TEXT,
+    logged_at       TIMESTAMPTZ NOT NULL,
+    modified_at     TIMESTAMPTZ NOT NULL,
+    ip_address      VARCHAR(50) NOT NULL,
+    changed_fields  jsonb       NOT NULL,
+    changed_by      VARCHAR(50) NOT NULL
+);
+
+
+
+
+
+


### PR DESCRIPTION
### JIRA (jira의 이슈 키 값을 명시해주세요)
- OPS-59

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] DB 관련

### 반영 브랜치
ex) feature/OPS-59-db-생성 -> dev

### 변경 사항
ERD 를 기반으로 DDL 정의가 완료되었습니다.
총 5개의 테이블이 생성되었습니다. 

❗초기 pr 이후 변경 사항
 1.  [OPS-80: Enum 형변환](https://edaily0129-1741827545913.atlassian.net/browse/OPS-80) 이슈로 enum type이 varchar로 변경되었습니다.
 2. employees와 backups 테이블의 files에 대한 `on delete` 설정이 `set null` -> `cascade` 로 변경되었습니다.

 추가적으로 기존 yaml 파일에 존재하는 database 유저 설정을 유지해주시길 바랍니다. :)

### 테스트 결과
테스트로 정상 생성 확인 되었습니다
![image](https://github.com/user-attachments/assets/49007a6f-4223-4e42-b24d-ebd6b260c536)
