### PR TITLE
OPS-50 feat: 공통 응답 생성, ErrorCode 정의

### DIFF
--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.sprint.example.sb01part2hrbankteam10.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+  HttpStatus getHttpStatus();
+
+  String getCode();
+
+  String getMessage();
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/ErrorResponse.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.sprint.example.sb01part2hrbankteam10.global.exception;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@JsonPropertyOrder({"timestamp", "status", "message", "details"})
+public class ErrorResponse {
+
+  private final LocalDateTime timestamp;
+  private final HttpStatus status;
+  private final String message;
+  private final String details;
+
+  @Builder
+  public ErrorResponse(LocalDateTime timestamp, HttpStatus status, String message, String details) {
+    this.timestamp = timestamp;
+    this.status = status;
+    this.message = message;
+    this.details = details;
+  }
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,75 @@
+package com.sprint.example.sb01part2hrbankteam10.global.exception;
+
+import com.sprint.example.sb01part2hrbankteam10.global.exception.errorcode.GlobalErrorCode;
+import com.sprint.example.sb01part2hrbankteam10.global.response.RestApiResponse;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(
+      MethodArgumentNotValidException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+
+    log.error("유효성 검사 실패 : {}", ex.getMessage());
+
+    ErrorResponse errorResponse = ErrorResponse.builder()
+        .timestamp(LocalDateTime.now())
+        .status(HttpStatus.BAD_REQUEST)
+        .message("유효성 검증에 실패하셨습니다.")
+        .details(ex.getMessage())
+        .build();
+
+    return handleExceptionInternal(errorResponse);
+  }
+
+  @ExceptionHandler(RestApiException.class)
+  public ResponseEntity<Object> handleCustomException(
+      RestApiException ex) {
+
+    log.error("에러 코드 : {}, 에러 발생 : {} ({})", ex.getErrorCode(), ex.getMessage(), ex.getDetails());
+
+    ErrorResponse errorResponse = ErrorResponse.builder()
+        .timestamp(LocalDateTime.now())
+        .status(ex.getErrorCode().getHttpStatus())
+        .message(ex.getErrorCode().getMessage())
+        .details(ex.getDetails())
+        .build();
+    return handleExceptionInternal(errorResponse);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Object> handleBadRequestException(
+      Exception ex) {
+
+    log.error("서버 에러 발생 : {}", ex.getMessage());
+
+    ErrorResponse errorResponse = ErrorResponse.builder()
+        .timestamp(LocalDateTime.now())
+        .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+        .message(GlobalErrorCode.INTERNAL_SERVER_ERROR.getMessage())
+        .build();
+    return handleExceptionInternal(errorResponse);
+  }
+
+  private ResponseEntity<Object> handleExceptionInternal(
+      ErrorResponse errorResponse) {
+    return ResponseEntity
+        .status(errorResponse.getStatus())
+        .body(RestApiResponse.failure(errorResponse));
+  }
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/RestApiException.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/RestApiException.java
@@ -1,0 +1,12 @@
+package com.sprint.example.sb01part2hrbankteam10.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RestApiException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+  private final String details;
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/errorcode/EmployeeErrorCode.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/errorcode/EmployeeErrorCode.java
@@ -1,0 +1,19 @@
+package com.sprint.example.sb01part2hrbankteam10.global.exception.errorcode;
+
+import com.sprint.example.sb01part2hrbankteam10.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmployeeErrorCode implements ErrorCode {
+
+  EMPLOYEE_NOT_FOUND(HttpStatus.NOT_FOUND, "EMPLOYEE_001", "해당 직원이 존재하지 않습니다."),
+  EMPLOYEE_IS_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "EMPLOYEE_002", "이미 존재하는 직원입니다.");
+  // 기본 유효성 검사는 @Valid 에서 하고, 중복 데이터 검사 등은 도메인 별로 ErrorCode 를 만들어 관리합니다.
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/exception/errorcode/GlobalErrorCode.java
@@ -1,0 +1,17 @@
+package com.sprint.example.sb01part2hrbankteam10.global.exception.errorcode;
+
+import com.sprint.example.sb01part2hrbankteam10.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_001", "담당자에게 문의해주세요.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/response/RestApiResponse.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/global/response/RestApiResponse.java
@@ -1,0 +1,48 @@
+package com.sprint.example.sb01part2hrbankteam10.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sprint.example.sb01part2hrbankteam10.global.exception.ErrorResponse;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+
+@Getter
+@JsonInclude(value = Include.NON_NULL)
+@Builder(access = AccessLevel.PRIVATE)
+public class RestApiResponse<T> {
+
+  private boolean success;
+  private String message;
+  private HttpStatus status;
+  @Nullable
+  private T data;
+  @Nullable
+  private ErrorResponse error;
+
+  public static <T> RestApiResponse<T> success(HttpStatus status, T data) {
+    return RestApiResponse.<T>builder()
+        .success(true)
+        .status(status)
+        .data(data)
+        .build();
+  }
+
+  public static RestApiResponse<Void> success(HttpStatus status, String message) {
+    return RestApiResponse.<Void>builder()
+        .success(true)
+        .status(status)
+        .message(message)
+        .build();
+  }
+
+  public static <T> RestApiResponse<T> failure(ErrorResponse errorResponse) {
+    return RestApiResponse.<T>builder()
+        .success(false)
+        .status(errorResponse.getStatus())
+        .error(errorResponse)
+        .build();
+  }
+}


### PR DESCRIPTION
### JIRA key
- OPS-50

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/OPS-50-api-response -> dev

### 변경 사항
- 공통 응답 객체 RestApiResponse 생성 : 모든 응답에 대한 class입니다.
- 에러 응답 객체 ErrorResponse 생성 : 에러 응답에 대한 class입니다.
- RestApiExcetion 커스텀 예외 생성
- GlobalExceptionHandler 생성 : 전역적 예외 처리를 위한 핸들러입니다.
> `@Valid` 에 대한 에러 처리를 포함합니다.

<br>

- ErrorCode 인터페이스 생성 
> 각자 도메인에 맞게 인터페이스를 기반으로 에러코드를 구현하시면 됩니다. (예시 코드 포함되어 있습니다.)
> 예시: ErrorCode를 implements 한 FileErrorCode 생성, 이후 필요한 에러코드 생성.

<br>

- 사용예시 (예외를 던지는 경우)
``` java
 //throw new RestApiExcetion( {해당 도메인 에러 코드}, {detail 메세지} );
 throw new RestApiExcetion(FileErrorCode.FILE_NOT_FOUND, id + "파일이 존재하지 않습니다.");
```
<br>
✔️주의 : 각자 구현하시는 도메인 ErrorCode 외에는 수정하시지 말아주시길 바랍니다. 관련 내용은 @yinneu  에게 알려주세요 :)

### 테스트 결과
구현 후 빌드 테스트 성공했습니다. 이후 문제가 있으시면 빠르게 알려주시면 감사하겠습니다. :)