### PR TITLE
OPS-79 feat: 엔티티 생성 및 JPA 적용

### DIFF
--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/Backup.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/Backup.java
@@ -1,0 +1,75 @@
+package com.sprint.example.sb01part2hrbankteam10.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Table(name = "backups")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Backup {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @CreationTimestamp
+  @Column(name = "created_at", columnDefinition= "timestamp with time zone", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @JoinColumn(name = "file_id")
+  private File file;
+
+  @Column(name = "started_at", columnDefinition= "timestamp with time zone", nullable = false)
+  private LocalDateTime startedAt;
+
+  @Column(name = "ended_at", columnDefinition= "timestamp with time zone")
+  private LocalDateTime endedAt;
+
+  @Column(name = "worker_ip_address", length = 255, nullable = false)
+  private String workerIpAddress;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private BackupStatus status;
+
+  @Column(name = "batch_done_at", columnDefinition= "timestamp with time zone")
+  private LocalDateTime batchDoneAt;
+
+  public enum BackupStatus {
+    IN_PROGRESS,
+    COMPLETED,
+    SKIPPED,
+    FAILED
+  }
+
+  @Builder
+  public Backup(File file, LocalDateTime startedAt, LocalDateTime endedAt, String workerIpAddress,
+      BackupStatus status, LocalDateTime batchDoneAt) {
+    this.file = file;
+    this.startedAt = startedAt;
+    this.endedAt = endedAt;
+    this.workerIpAddress = workerIpAddress;
+    this.status = status;
+    this.batchDoneAt = batchDoneAt;
+  }
+}
+

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/Department.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/Department.java
@@ -1,0 +1,45 @@
+package com.sprint.example.sb01part2hrbankteam10.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "departments")
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Department {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @CreationTimestamp
+  @Column(name = "created_at", columnDefinition= "timestamp with time zone", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "name", length = 50, nullable = false, unique = true)
+  private String name;
+
+  @Column(name = "description", length = 255, nullable = false)
+  private String description;
+
+  @Column(name = "established_date", nullable = false)
+  private LocalDateTime establishedDate;
+
+  @Builder
+  public Department(String name, String description, LocalDateTime establishedDate) {
+    this.name = name;
+    this.description = description;
+    this.establishedDate = establishedDate;
+  }
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/Employee.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/Employee.java
@@ -1,0 +1,86 @@
+package com.sprint.example.sb01part2hrbankteam10.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Table(name = "employees")
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Employee {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @Column(name = "name", length = 50, nullable = false)
+  private String name;
+
+  @Column(name = "email", length = 100, nullable = false, unique = true)
+  private String email;
+
+  @Column(name = "employee_number", length = 255, nullable = false, updatable = false, unique = true)
+  private String employeeNumber;
+
+  @Column(name = "position", length = 255)
+  private String position;
+
+  @Column(name = "hire_date", columnDefinition= "timestamp with time zone", nullable = false)
+  private LocalDateTime hireDate;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private EmployeeStatus status;
+
+  @CreationTimestamp
+  @Column(name = "created_at", columnDefinition= "timestamp with time zone", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "department_id", columnDefinition = "INTEGER")
+  @OnDelete(action = OnDeleteAction.RESTRICT)
+  private Department department;
+
+  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @JoinColumn(name = "profile_image_id")
+  private File profileImage;
+
+  public enum EmployeeStatus{
+    ACTIVE,
+    RESIGNED,
+    ON_LEAVE
+  }
+
+  @Builder
+  public Employee(String name, String email, String employeeNumber, String position,
+      LocalDateTime hireDate, EmployeeStatus status, Department department, File profileImage) {
+    this.name = name;
+    this.email = email;
+    this.employeeNumber = employeeNumber;
+    this.position = position;
+    this.hireDate = hireDate;
+    this.status = status;
+    this.department = department;
+    this.profileImage = profileImage;
+  }
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/EmployeeHistory.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/EmployeeHistory.java
@@ -1,0 +1,69 @@
+package com.sprint.example.sb01part2hrbankteam10.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "employee_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmployeeHistory {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @Column(name = "employee_number", nullable = false, length = 50)
+  private String employeeNumber;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "type", nullable = false)
+  private ChangeType type;
+
+  @Column(name = "memo", columnDefinition = "TEXT")
+  private String memo;
+
+  @Column(name = "modified_at", nullable = false)
+  private LocalDateTime modifiedAt;
+
+  @Column(name = "ip_address", nullable = false, length = 50)
+  private String ipAddress;
+
+  @Column(name = "changed_fields", columnDefinition = "jsonb", nullable = false)
+  private String changedFields;
+
+  @CreationTimestamp
+  @Column(name = "logged_at", columnDefinition= "timestamp with time zone", nullable = false, updatable = false)
+  private LocalDateTime loggedAt;
+
+  @Column(name = "changed_by", nullable = false, length = 50)
+  private String changedBy;
+
+  @Builder
+  public EmployeeHistory(String employeeNumber, ChangeType type, String memo,
+      LocalDateTime modifiedAt, String ipAddress, String changedFields, String changedBy) {
+    this.employeeNumber = employeeNumber;
+    this.type = type;
+    this.memo = memo;
+    this.modifiedAt = modifiedAt;
+    this.ipAddress = ipAddress;
+    this.changedFields = changedFields;
+    this.changedBy = changedBy;
+  }
+
+  public enum ChangeType {
+    CREATED, UPDATED, DELETED
+  }
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/File.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/File.java
@@ -1,0 +1,45 @@
+package com.sprint.example.sb01part2hrbankteam10.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Table;
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "files")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class File {
+  @Id
+  @GeneratedValue(strategy= GenerationType.IDENTITY)
+  private Integer id;
+
+  @Column(name = "name", length = 255, nullable = false)
+  private String name;
+
+  @Column(name = "content_type", length = 100, nullable = false)
+  private String contentType;
+
+  @Column(name = "size", nullable = false)
+  private BigInteger size;
+
+  @CreationTimestamp
+  @Column(name = "created_at", columnDefinition= "timestamp with time zone", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public File(String name, String contentType, BigInteger size) {
+    this.name = name;
+    this.contentType = contentType;
+    this.size = size;
+  }
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/BackupRepository.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/BackupRepository.java
@@ -1,0 +1,10 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import com.sprint.example.sb01part2hrbankteam10.entity.Backup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BackupRepository extends JpaRepository<Backup, Integer> {
+
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/DepartmentRepository.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/DepartmentRepository.java
@@ -1,0 +1,12 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import com.sprint.example.sb01part2hrbankteam10.entity.Department;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DepartmentRepository extends JpaRepository<Department, Integer> {
+
+  Optional<Object> findByName(String name);
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/EmployeeHistoryRepository.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/EmployeeHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import com.sprint.example.sb01part2hrbankteam10.entity.EmployeeHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmployeeHistoryRepository extends JpaRepository<EmployeeHistory, Integer> {
+
+
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/EmployeeRepository.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/EmployeeRepository.java
@@ -1,0 +1,10 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import com.sprint.example.sb01part2hrbankteam10.entity.Employee;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmployeeRepository extends JpaRepository<Employee, Integer> {
+
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/FileRepository.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/repository/FileRepository.java
@@ -1,0 +1,10 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import com.sprint.example.sb01part2hrbankteam10.entity.File;
+import org.springframework.context.annotation.ReflectiveScan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@ReflectiveScan
+public interface FileRepository extends JpaRepository<File,Integer> {
+
+}

--- a/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/BackupRepositoryTest.java
+++ b/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/BackupRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.sprint.example.sb01part2hrbankteam10.entity.Backup;
+import com.sprint.example.sb01part2hrbankteam10.entity.Backup.BackupStatus;
+import com.sprint.example.sb01part2hrbankteam10.entity.File;
+import jakarta.transaction.Transactional;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 지금 설정된 실제 데이터 베이스를 사용하도록 설정
+@Transactional // 테스트 후 자동으로 롤백되도록 설정
+class BackupRepositoryTest {
+
+  @Autowired
+  private BackupRepository backupRepository;
+  @Autowired
+  private FileRepository fileRepository;
+
+  @Test
+  void testSaveBackup() {
+    // given
+    // 파일 생성
+    File file = File.builder()
+        .name("backup1")
+        .contentType("application/zip")
+        .size(new BigInteger("1024"))
+        .build();
+    fileRepository.save(file);
+
+    // 백업 파일 생성 : 파일이 널이 아닐 때
+    Backup backupFileNotNull = Backup.builder()
+        .file(file)
+        .startedAt(LocalDateTime.now())
+        .endedAt(LocalDateTime.now())
+        .workerIpAddress(InetAddress.getLoopbackAddress().getHostAddress())
+        .status(BackupStatus.COMPLETED)
+        .batchDoneAt(LocalDateTime.now())
+        .build();
+    backupRepository.save(backupFileNotNull);
+
+    // 백업 생성 : 파일이 널일 때
+    Backup backupFileIsNull = Backup.builder()
+        .file(null)
+        .startedAt(LocalDateTime.now())
+        .endedAt(LocalDateTime.now())
+        .workerIpAddress(InetAddress.getLoopbackAddress().getHostAddress())
+        .status(BackupStatus.FAILED)
+        .batchDoneAt(LocalDateTime.now())
+        .build();
+    backupRepository.save(backupFileIsNull);
+
+    // when
+    // 파일이 널이 아닐 때
+    Backup resultCreateFileNotNull = backupRepository.findById(backupFileNotNull.getId()).orElseThrow();
+    // 파일이 널일 때
+    Backup resultCreateFileIsNull = backupRepository.findById(backupFileIsNull.getId()).orElseThrow();
+
+    // then
+    // 파일이 널이 아닐 때
+    assertEquals(backupFileNotNull.getFile(), resultCreateFileNotNull.getFile());
+    assertEquals(backupFileNotNull.getStartedAt(), resultCreateFileNotNull.getStartedAt());
+    assertEquals(backupFileNotNull.getEndedAt(), resultCreateFileNotNull.getEndedAt());
+    assertEquals(backupFileNotNull.getWorkerIpAddress(), resultCreateFileNotNull.getWorkerIpAddress());
+    assertEquals(backupFileNotNull.getStatus(), resultCreateFileNotNull.getStatus());
+    assertEquals(backupFileNotNull.getBatchDoneAt(), resultCreateFileNotNull.getBatchDoneAt());
+
+    // 파일이 널일 때
+    assertEquals(backupFileIsNull.getFile(), resultCreateFileIsNull.getFile());
+    assertEquals(backupFileIsNull.getStartedAt(), resultCreateFileIsNull.getStartedAt());
+    assertEquals(backupFileIsNull.getEndedAt(), resultCreateFileIsNull.getEndedAt());
+    assertEquals(backupFileIsNull.getWorkerIpAddress(), resultCreateFileIsNull.getWorkerIpAddress());
+    assertEquals(backupFileIsNull.getStatus(), resultCreateFileIsNull.getStatus());
+    assertEquals(backupFileIsNull.getBatchDoneAt(), resultCreateFileIsNull.getBatchDoneAt());
+  }
+
+  @Test
+  void testDeleteBackup() {
+    // given
+    // 파일 생성
+    File file = File.builder()
+        .name("backup1")
+        .contentType("application/zip")
+        .size(new BigInteger("1024"))
+        .build();
+    fileRepository.save(file);
+
+    Backup backup = Backup.builder()
+        .file(file)
+        .startedAt(LocalDateTime.now())
+        .endedAt(LocalDateTime.now())
+        .workerIpAddress(InetAddress.getLoopbackAddress().getHostAddress())
+        .status(BackupStatus.COMPLETED)
+        .batchDoneAt(LocalDateTime.now())
+        .build();
+    backupRepository.save(backup);
+
+    // when
+    backupRepository.delete(backup);
+
+    // then
+    // 백업 삭제
+    assertNull(backupRepository.findById(backup.getId()).orElse(null));
+    // 파일도 같이 삭제 됐는지 확인 (참조관계)
+    assertNull(fileRepository.findById(file.getId()).orElse(null));
+  }
+}

--- a/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/DepartmentRepositoryTest.java
+++ b/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/DepartmentRepositoryTest.java
@@ -1,0 +1,109 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.sprint.example.sb01part2hrbankteam10.entity.Department;
+import com.sprint.example.sb01part2hrbankteam10.entity.Employee;
+import com.sprint.example.sb01part2hrbankteam10.entity.Employee.EmployeeStatus;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 지금 설정된 실제 데이터 베이스를 사용하도록 설정
+@Transactional // 테스트 후 자동으로 롤백되도록 설정
+class DepartmentRepositoryTest {
+
+  @Autowired
+  private DepartmentRepository departmentRepository;
+  @Autowired
+  private EmployeeRepository employeeRepository;
+
+  @Test
+  void testSaveDepartment() {
+    //given
+    Department department = Department.builder()
+        .name("hr")
+        .description("인사팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    departmentRepository.save(department);
+
+    // when (생성, 수정, 삭제 (직원 존재 시 삭제되면 안됨))
+    Department result = departmentRepository.findById(department.getId()).orElseThrow();
+
+    // then
+    assertEquals(department.getName(), result.getName());
+    assertEquals(department.getDescription(), result.getDescription());
+    assertEquals(department.getEstablishedDate(), result.getEstablishedDate());
+  }
+
+  @Test
+  void testUpdateDepartment() {
+    //given
+    Department department = Department.builder()
+        .name("hr2")
+        .description("인사팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    departmentRepository.save(department);
+
+    Department updateDepartment = departmentRepository.findById(department.getId()).orElseThrow();
+
+
+    // when (생성, 수정, 삭제 (직원 존재 시 삭제되면 안됨))
+    updateDepartment.setName("nohr");
+    Department result = departmentRepository.save(updateDepartment);
+
+    // then
+    assertEquals("nohr", result.getName());
+    assertEquals(department.getDescription(), result.getDescription());
+    assertEquals(department.getEstablishedDate(), result.getEstablishedDate());
+  }
+
+  @Test
+  void testDeleteDepartment() {
+    //given
+    Department department = Department.builder()
+        .name("hr")
+        .description("인사팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department saveDepartment = departmentRepository.save(department);
+
+    Department devDepartment = Department.builder()
+        .name("hr")
+        .description("인사팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department saveNoEmplDepartment = departmentRepository.save(department);
+
+    Employee employee = Employee.builder()
+        .name("yerim")
+        .email("yerim@gmail.com")
+        .profileImage(null)
+        .employeeNumber("num-011")
+        .department(saveDepartment)
+        .hireDate(LocalDateTime.now())
+        .status(EmployeeStatus.ACTIVE)
+        .position("개발자")
+        .build();
+    employeeRepository.save(employee);
+
+    // when (생성, 수정, 삭제 (직원 존재 시 삭제되면 안됨))
+
+//    departmentRepository.deleteById(saveNoEmplDepartment.getId());
+    try {
+      departmentRepository.deleteById(saveDepartment.getId());
+    } catch (Exception e) {
+      assertNotNull(departmentRepository.findById(saveDepartment.getId()).orElse(null));
+    }
+
+    // then
+//    assertNull(departmentRepository.findById(saveNoEmplDepartment.getId()).orElse(null));
+//    assertNotNull(departmentRepository.findById(saveDepartment.getId()).orElse(null));
+  }
+}

--- a/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/EmployeeHistoryRepositoryTest.java
+++ b/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/EmployeeHistoryRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.example.sb01part2hrbankteam10.entity.Department;
+import com.sprint.example.sb01part2hrbankteam10.entity.Employee;
+import com.sprint.example.sb01part2hrbankteam10.entity.Employee.EmployeeStatus;
+import com.sprint.example.sb01part2hrbankteam10.entity.EmployeeHistory;
+import com.sprint.example.sb01part2hrbankteam10.entity.EmployeeHistory.ChangeType;
+import io.swagger.v3.core.util.Json;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 지금 설정된 실제 데이터 베이스를 사용하도록 설정
+@Transactional // 테스트 후 자동으로 롤백되도록 설정
+class EmployeeHistoryRepositoryTest {
+
+  @Autowired
+  private EmployeeHistoryRepository employeeHistoryRepository;
+  @Autowired
+  private DepartmentRepository departmentRepository;
+  @Autowired
+  private EmployeeRepository employeeRepository;
+
+  @Test
+  void testSaveEmployeeHistory() {
+
+    // given
+    /*
+    this.employeeNumber = employeeNumber;
+    this.type = type;
+    this.memo = memo;
+    this.modifiedAt = modifiedAt;
+    this.ipAddress = ipAddress;
+    this.changedFields = changedFields;
+    this.changedBy = changedBy;
+     */
+    Department department = Department.builder()
+        .name("hr")
+        .description("인사팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department saveDepartment = departmentRepository.save(department);
+
+    Employee employee = Employee.builder()
+        .name("yerim")
+        .email("yerim@gmail.com")
+        .profileImage(null)
+        .employeeNumber("num-011")
+        .department(saveDepartment)
+        .hireDate(LocalDateTime.now())
+        .status(EmployeeStatus.ACTIVE)
+        .position("개발자")
+        .build();
+
+    List<HashMap<String, String>> change = new ArrayList<>();
+    change.add(new HashMap<>());
+    change.get(0).put("changeField", "name");
+    change.get(0).put("changeValue", "hello");
+    change.get(0).put("oldValue", "yerim");
+    ObjectMapper mapper = new ObjectMapper();
+    String changeFields = null;
+    try {
+      changeFields = mapper.writeValueAsString(change);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+
+    EmployeeHistory employeeHistory = EmployeeHistory.builder()
+        .employeeNumber(employee.getEmployeeNumber())
+        .type(ChangeType.CREATED)
+        .memo("memo")
+        .changedBy("dada")
+        .modifiedAt(LocalDateTime.now())
+        .ipAddress("127.0.0.1")
+        .changedFields(changeFields)
+        .build();
+    employeeHistoryRepository.save(employeeHistory);
+
+    // when
+    EmployeeHistory getEmployeeHistory = employeeHistoryRepository.findById(employeeHistory.getId()).orElseThrow();
+
+    // then
+    assertEquals(getEmployeeHistory.getEmployeeNumber(), getEmployeeHistory.getEmployeeNumber());
+    assertEquals(changeFields, getEmployeeHistory.getChangedFields());
+  }
+}

--- a/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/EmployeeRepositoryTest.java
+++ b/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/EmployeeRepositoryTest.java
@@ -1,0 +1,273 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.sprint.example.sb01part2hrbankteam10.entity.Department;
+import com.sprint.example.sb01part2hrbankteam10.entity.Employee;
+import com.sprint.example.sb01part2hrbankteam10.entity.Employee.EmployeeStatus;
+import com.sprint.example.sb01part2hrbankteam10.entity.File;
+import jakarta.transaction.Transactional;
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE) // 지금 설정된 실제 데이터 베이스를 사용하도록 설정
+@Transactional // 테스트 후 자동으로 롤백되도록 설정
+public class EmployeeRepositoryTest {
+
+  @Autowired
+  private EmployeeRepository employeeRepository;
+  @Autowired
+  private DepartmentRepository departmentRepository;
+  @Autowired
+  private FileRepository fileRepository;
+
+  @Test
+  void testSaveEmployeeWithDepartment() {
+
+    //given
+    Department department = Department.builder()
+        .name("hr")
+        .description("인사팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department saveDepartment = departmentRepository.save(department);
+
+    Employee employee = Employee.builder()
+        .name("yerim")
+        .email("yerim@gmail.com")
+        .profileImage(null)
+        .employeeNumber("num-011")
+        .department(saveDepartment)
+        .hireDate(LocalDateTime.now())
+        .status(EmployeeStatus.ACTIVE)
+        .position("개발자")
+        .build();
+    employeeRepository.save(employee);
+
+    // when
+    Employee saveEmployee = employeeRepository.findById(employee.getId()).orElseThrow();
+
+    // then
+    assertEquals("yerim", saveEmployee.getName());
+    assertEquals("yerim@gmail.com", saveEmployee.getEmail());
+    assertEquals("num-011", saveEmployee.getEmployeeNumber());
+    assertEquals("hr", saveEmployee.getDepartment().getName());
+  }
+
+  @Test
+  void testSaveEmployeeWithProfile() {
+
+    //given
+    Department department = Department.builder()
+        .name("hr")
+        .description("인사팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department saveDepartment = departmentRepository.save(department);
+
+    File profile = File.builder()
+        .name("backup1")
+        .contentType("application/zip")
+        .size(new BigInteger("1024"))
+        .build();
+    File saveProfile = fileRepository.save(profile);
+
+    Employee employee = Employee.builder()
+        .name("yerim")
+        .email("yerim@gmail.com")
+        .profileImage(saveProfile)
+        .employeeNumber("num-011")
+        .department(saveDepartment)
+        .hireDate(LocalDateTime.now())
+        .status(EmployeeStatus.ACTIVE)
+        .position("개발자")
+        .build();
+    employeeRepository.save(employee);
+
+    // when
+    Employee saveEmployee = employeeRepository.findById(employee.getId()).orElseThrow();
+
+    // then
+    assertEquals("backup2", saveEmployee.getProfileImage().getName());
+    assertEquals(saveProfile.getContentType(), saveEmployee.getProfileImage().getContentType());
+    assertEquals(saveProfile.getSize(), saveEmployee.getProfileImage().getSize());
+  }
+
+  @Test
+  void testUpdateEmployeeWithDepartment() { // 부서
+
+    //given
+    Department department = Department.builder()
+        .name("hr")
+        .description("인사팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department saveDepartment = departmentRepository.save(department);
+
+    Department department2 = Department.builder()
+        .name("dev")
+        .description("개발팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department saveDepartment2 = departmentRepository.save(department2);
+
+    Employee employee = Employee.builder() // 인사팀
+        .name("yerim")
+        .email("yerim@gmail.com")
+        .profileImage(null)
+        .employeeNumber("num-011")
+        .department(saveDepartment)
+        .hireDate(LocalDateTime.now())
+        .status(EmployeeStatus.ACTIVE)
+        .position("개발자")
+        .build();
+    Employee saveEmployee = employeeRepository.save(employee);
+
+    // when
+    Employee getEmployee = employeeRepository.findById(saveEmployee.getId()).orElseThrow();
+    getEmployee.setDepartment(saveDepartment2); // 개발팀
+    Employee updateEmployee = employeeRepository.save(getEmployee);
+    Department hrDepartment = departmentRepository.findById(department.getId()).orElse(null);
+
+    // then
+    assertEquals("yerim", updateEmployee.getName());
+    assertEquals("yerim@gmail.com", updateEmployee.getEmail());
+    assertEquals("num-011", updateEmployee.getEmployeeNumber());
+    assertEquals("dev", updateEmployee.getDepartment().getName());
+    assertEquals(saveDepartment, hrDepartment);
+  }
+
+  @Test
+  void testUpdateEmployeeWithProfile() {
+
+    //given
+    Department department = Department.builder()
+        .name("hr")
+        .description("인사팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department saveDepartment = departmentRepository.save(department);
+
+    File profile = File.builder()
+        .name("backup1")
+        .contentType("application/zip")
+        .size(new BigInteger("1024"))
+        .build();
+    File saveProfile = fileRepository.save(profile);
+
+    Employee employee = Employee.builder()
+        .name("yerim")
+        .email("yerim@gmail.com")
+        .profileImage(saveProfile)
+        .employeeNumber("num-011")
+        .department(saveDepartment)
+        .hireDate(LocalDateTime.now())
+        .status(EmployeeStatus.ACTIVE)
+        .position("개발자")
+        .build();
+    Employee preEmployee = employeeRepository.save(employee);
+
+    // when
+
+    // 업데이트
+    Employee saveEmployee = employeeRepository.findById(preEmployee.getId()).orElseThrow();
+
+    File newProfile = File.builder()
+        .name("new")
+        .contentType("application/zip")
+        .size(new BigInteger("1024"))
+        .build();
+    saveEmployee.setProfileImage(fileRepository.save(newProfile));
+
+    Employee updateEmployee = employeeRepository.save(saveEmployee); // 새 프로필로 설정
+
+    // 이전 프로필 삭제 확인
+    fileRepository.deleteById(profile.getId());
+    File deleteProfile = fileRepository.findById(profile.getId()).orElse(null);
+
+    // then
+    assertEquals("new",updateEmployee.getProfileImage().getName());
+    assertNull(deleteProfile);
+  }
+
+  @Test
+  void testDeleteEmployeeWithDepartment() {
+
+    // given
+    Department department2 = Department.builder()
+        .name("dev")
+        .description("개발팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department devDepartment = departmentRepository.save(department2);
+
+    Employee employee = Employee.builder() // 인사팀
+        .name("yerim")
+        .email("yerim@gmail.com")
+        .profileImage(null)
+        .employeeNumber("num-011")
+        .department(devDepartment)
+        .hireDate(LocalDateTime.now())
+        .status(EmployeeStatus.ACTIVE)
+        .position("개발자")
+        .build();
+    Employee saveEmployee = employeeRepository.save(employee);
+
+    // when
+    employeeRepository.deleteById(saveEmployee.getId());
+    Employee getEmployee = employeeRepository.findById(saveEmployee.getId()).orElse(null);
+    Department getDepartment = departmentRepository.findById(devDepartment.getId()).orElse(null);
+
+    // then
+    assertNull(getEmployee);
+    assertEquals(devDepartment, getDepartment);
+  }
+
+  @Test
+  void testDeleteEmployeeWithProfile() {
+
+    // given
+    Department department2 = Department.builder()
+        .name("dev")
+        .description("개발팀")
+        .establishedDate(LocalDateTime.now())
+        .build();
+    Department devDepartment = departmentRepository.save(department2);
+
+    File profile = File.builder()
+        .name("backup1")
+        .contentType("application/zip")
+        .size(new BigInteger("1024"))
+        .build();
+    File saveProfile = fileRepository.save(profile);
+
+    Employee employee = Employee.builder() // 인사팀
+        .name("yerim")
+        .email("yerim@gmail.com")
+        .profileImage(saveProfile)
+        .employeeNumber("num-011")
+        .department(devDepartment)
+        .hireDate(LocalDateTime.now())
+        .status(EmployeeStatus.ACTIVE)
+        .position("개발자")
+        .build();
+    Employee saveEmployee = employeeRepository.save(employee);
+
+    // when
+    employeeRepository.deleteById(saveEmployee.getId());
+    Employee getEmployee = employeeRepository.findById(saveEmployee.getId()).orElse(null);
+    Department getDepartment = departmentRepository.findById(devDepartment.getId()).orElse(null);
+    File getProfile = fileRepository.findById(saveProfile.getId()).orElse(null);
+
+    // then
+    assertNull(getEmployee);
+    assertNull(getProfile);
+    assertEquals(devDepartment, getDepartment);
+  }
+}

--- a/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/FileRepositoryTest.java
+++ b/src/test/java/com/sprint/example/sb01part2hrbankteam10/repository/FileRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.sprint.example.sb01part2hrbankteam10.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.sprint.example.sb01part2hrbankteam10.entity.File;
+import jakarta.transaction.Transactional;
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 지금 설정된 실제 데이터 베이스를 사용하도록 설정
+@Transactional // 테스트 후 자동으로 롤백되도록 설정
+class FileRepositoryTest {
+
+  @Autowired
+  private FileRepository fileRepository;
+
+  @Test // 생성 테스트
+  void testSaveFile() {
+
+    // given
+    File file = File.builder()
+        .name("backup1")
+        .contentType("application/zip")
+        .size(new BigInteger("1024"))
+        .build();
+    fileRepository.save(file);
+
+    // when
+    File resultCreate = fileRepository.findById(file.getId()).orElse(null);
+
+    // then
+    assertNotNull(resultCreate);
+    assertEquals(file.getName(), resultCreate.getName());
+    assertEquals(file.getContentType(), resultCreate.getContentType());
+    assertEquals(file.getSize(), resultCreate.getSize());
+  }
+
+  @Test // 삭제 테스트
+  void testDeleteFile() {
+
+    // given
+    File file = File.builder()
+        .name("backup1")
+        .contentType("application/zip")
+        .size(new BigInteger("1024"))
+        .build();
+    fileRepository.save(file);
+
+    // when
+    fileRepository.deleteById(file.getId());
+    File getFile = fileRepository.findById(file.getId()).orElse(null);
+
+    // then
+    assertNull(getFile);
+  }
+}


### PR DESCRIPTION
### JIRA (jira의 이슈 키 값을 명시해주세요)
- OPS-79

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/OPS-79-엔티티-생성-및-jpa-적용

### 변경 사항
엔티티 생성 후 JPA 어노테이션을 추가했습니다. 이후 단위 테스트 코드 작성을 통해 JPA 기본 동작 테스트를 진행했습니다.

### 테스트 결과
![image](https://github.com/user-attachments/assets/bc324b6d-7ab2-4b99-8a49-db1522ff7177)
