### PR TITLE
fix: backup file 저장 로직 수정

### DIFF
--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/storage/FileStorage.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/storage/FileStorage.java
@@ -12,9 +12,6 @@ public interface FileStorage {
   // 백업 파일 저장
   Integer saveBackup(Integer fileId, MultipartFile file);
 
-  // 프로필 파일 경로 생성
-  Path profileResolvePath(Integer fileId);
-
-  // 백업 파일 경로 생성
-  Path backupResolvePath(Integer fileId);
+  // 파일 경로 생성
+  Path resolvePath(Integer fileId);
 }

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/storage/impl/FileStorageImpl.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/storage/impl/FileStorageImpl.java
@@ -4,6 +4,7 @@ import com.sprint.example.sb01part2hrbankteam10.global.exception.RestApiExceptio
 import com.sprint.example.sb01part2hrbankteam10.global.exception.errorcode.FileErrorCode;
 import com.sprint.example.sb01part2hrbankteam10.storage.FileStorage;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,21 +17,18 @@ import org.springframework.web.multipart.MultipartFile;
 public class FileStorageImpl implements FileStorage {
 
   // 저장 디렉토리 경로 선언
-  private final Path profileStorage;
-  private final Path backupStorage;
+  private final Path rootStorage;
 
   // 경로 의존성 주입 생성자
-  public FileStorageImpl(@Value("${user.dir}/savedFiles/profiles") String profileStorage, @Value("${user.dir}/savedFiles/backups")String backupStorage) {
-    this.profileStorage= Path.of(profileStorage);
-    this.backupStorage = Path.of(backupStorage);
+  public FileStorageImpl(@Value("${user.dir}/savedFiles") String rootStorage) {
+    this.rootStorage= Path.of(rootStorage);
     init();
   }
 
   // 해당 디렉토리가 없을 시 만들어주는 초기화 메서드
   private void init(){
     try {
-      Files.createDirectories(profileStorage);
-      Files.createDirectories(backupStorage);
+      Files.createDirectories(rootStorage);
     } catch(IOException e){
       throw new RestApiException(FileErrorCode.DIRECTORY_CREATION_FAILED, e.getMessage());
     }
@@ -40,7 +38,7 @@ public class FileStorageImpl implements FileStorage {
   @Override
   public Integer saveProfile(Integer fileId, MultipartFile file){
     // fileId로 경로 생성 -> resolvePath
-    Path path = profileResolvePath(fileId);
+    Path path = resolvePath(fileId);
 
     // byte[] data를 로컬저장소에 넣기
     try{
@@ -54,37 +52,31 @@ public class FileStorageImpl implements FileStorage {
 
   // 백업 파일 저장
   @Override
-  public Integer saveBackup(Integer fileId, MultipartFile file){
-    // fileId로 경로 생성 -> resolvePath
-    Path path = backupResolvePath(fileId);
+  public Integer saveBackup(Integer fileId, MultipartFile file) {
+    // fileId로 경로 생성
+    Path path = resolvePath(fileId);
 
-    // file 데이터 output stream 생성
-    try(OutputStream outputStream = Files.newOutputStream(path)){
-      outputStream.write(file.getBytes());
-    }catch(IOException e){
+    // 파일을 스트림을 통해 저장
+    try (InputStream inputStream = file.getInputStream();
+        OutputStream outputStream = Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+
+      byte[] buffer = new byte[32768]; // 32KB씩 저장
+      int bytesRead;
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        outputStream.write(buffer, 0, bytesRead);
+      }
+    } catch (IOException e) {
       throw new RestApiException(FileErrorCode.FILE_STREAM_ERROR, e.getMessage());
     }
 
-    // byte[] data를 로컬저장소에 넣기
-    try{
-      byte[] data = file.getBytes();
-      Files.write(path, data, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-    }catch(IOException e){
-      throw new RestApiException(FileErrorCode.FILE_WRITE_ERROR, e.getMessage());
-    }
     return fileId;
   }
 
-  // 프로필 - 아이디로 경로를 설정하는 메서드 resolvePath
-  @Override
-  public Path profileResolvePath(Integer fileId){
-    return profileStorage.resolve(fileId.toString());
-  }
 
-  // 백업 - 아이디로 경로를 설정하는 메서드 resolvePath
+  // 아이디로 경로를 설정하는 메서드 resolvePath
   @Override
-  public Path backupResolvePath(Integer fileId){
-    return backupStorage.resolve(fileId.toString());
+  public Path resolvePath(Integer fileId){
+    return rootStorage.resolve(fileId.toString());
   }
 }
 

--- a/src/test/java/com/sprint/example/sb01part2hrbankteam10/storage/impl/FileStorageImplTest.java
+++ b/src/test/java/com/sprint/example/sb01part2hrbankteam10/storage/impl/FileStorageImplTest.java
@@ -43,11 +43,11 @@ class FileStorageImplTest {
 
     // then
     // 프로필 파일이 savedFiles/profiles에 저장되었나 확인
-    Path profilePath = fileStorage.profileResolvePath(savedProfileId);
+    Path profilePath = fileStorage.resolvePath(savedProfileId);
     File savedProfileFile = new File("profilePath");
 
     // 백업 파일이 savedFiles/backups에 저장되었나 확인
-    Path backupPath = fileStorage.backupResolvePath(savedBackupId);
+    Path backupPath = fileStorage.resolvePath(savedBackupId);
     File savedBackupFile = new File("backupPath");
   }
 


### PR DESCRIPTION
### JIRA (jira의 이슈 키 값을 명시해주세요)
- OPS-32

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/OPS-32-save-file -> dev

### 변경 사항
- 백업 파일 스트리밍 방식 저장 로직 수정했습니다.
- 🔥지금 이 PR은 다운로드 구현 PR이 머지 되기 전에 수정했습니다. 수정하는 과정에서 다운로드 구현 시 수정했던 부분이 수정되어야 제 저장로직이 작동해서 불가피하게 저장 로직 수정중에도 해당 부분을 수정했습니다. 그래서 이 부분이 충돌날 것 같습니다. 그런데 둘 다 변경한 내용이 똑같기 때문에 그냥 한쪽으로 바로 덮어써 충돌 해결하면 될 것 같습니다.

### 테스트 결과 (api 테스트 결과를 포함해주세요.)
![image](https://github.com/user-attachments/assets/b18219fd-dc83-4f6f-9022-c84c83e16602)
