### PR TITLE
Fix/ops 141 backup 프론트 연결 수정

### DIFF
--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/controller/BackupController.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/controller/BackupController.java
@@ -2,6 +2,7 @@ package com.sprint.example.sb01part2hrbankteam10.controller;
 
 import com.sprint.example.sb01part2hrbankteam10.controller.docs.BackupDocs;
 import com.sprint.example.sb01part2hrbankteam10.dto.BackupDto;
+import com.sprint.example.sb01part2hrbankteam10.dto.CursorPageResponseBackupDto;
 import com.sprint.example.sb01part2hrbankteam10.entity.Backup;
 import com.sprint.example.sb01part2hrbankteam10.mapper.BackupMapper;
 import com.sprint.example.sb01part2hrbankteam10.repository.BackupRepository;
@@ -18,8 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 @RestController
 @RequestMapping("api/backups")
@@ -29,7 +29,7 @@ public class BackupController implements BackupDocs {
     private final BackupService backupService;
     private final BackupRepository backupRepository;
 
-    // 백업 요청 TODO 에러 코드
+    // 백업 요청
     @PostMapping
     @Override
     public ResponseEntity<Integer> backup(HttpServletRequest request) {
@@ -37,7 +37,7 @@ public class BackupController implements BackupDocs {
         return ResponseEntity.status(HttpStatus.OK).body(backupId);
     }
 
-    // 백업 상태로 가장 최근 백업 얻기 TODO 에러 코드
+    // 백업 상태로 가장 최근 백업 얻기
     @GetMapping("/latest")
     @Override
     public ResponseEntity<BackupDto> getLastBackup(@RequestParam Backup.BackupStatus status){
@@ -46,10 +46,10 @@ public class BackupController implements BackupDocs {
         return ResponseEntity.status(HttpStatus.OK).body(lastBackupDto);
     }
 
-    // 백업 목록 조회 - TODO 에러 코드
+    // 백업 목록 조회
     @GetMapping
     @Override
-    public ResponseEntity<Map<String, Object>> getBackupList(
+    public ResponseEntity<CursorPageResponseBackupDto> getBackupList(
             @RequestParam(required = false) String worker,
             @RequestParam(required = false) Backup.BackupStatus status,
             @RequestParam(required = false) LocalDateTime startedAtFrom,
@@ -62,17 +62,22 @@ public class BackupController implements BackupDocs {
         Pageable pageable = PageRequest.of(0, size, Sort.by(sortDirection, sortField));
         Page<BackupDto> backupPage = backupService.getBackupList(worker, status, startedAtFrom, startedAtTo, idAfter, null, size, sortField, sortDirection);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("content", backupPage.getContent());
-        response.put("nextCursor", backupPage.hasNext() ? encodeCursor(backupPage.getContent().get(backupPage.getContent().size() - 1)) : null);
-        response.put("nextIdAfter", backupPage.getContent().isEmpty() ? null : backupPage.getContent().get(backupPage.getContent().size() - 1).getId());
-        response.put("size", backupPage.getSize());
-        response.put("totalElements", backupPage.getTotalElements());
-        response.put("hasNext", backupPage.hasNext());
+        List<BackupDto> content = backupPage.getContent();
+        String nextCursor = backupPage.hasNext() && !content.isEmpty() ?
+                encodeCursor(content.get(content.size() - 1)) : null;
+        Integer nextIdAfter = content.isEmpty() ? null : content.get(content.size() - 1).getId();
+
+        CursorPageResponseBackupDto response = CursorPageResponseBackupDto.builder()
+                .content(content)  // Page 객체가 아닌 content 리스트를 전달
+                .nextCursor(nextCursor)
+                .nextIdAfter(nextIdAfter)
+                .size(backupPage.getSize())
+                .totalElements((int) backupPage.getTotalElements())
+                .hasNext(backupPage.hasNext())
+                .build();
 
         return ResponseEntity.ok(response);
     }
-
     private String encodeCursor(BackupDto backupDto) {
         if (backupDto == null || backupDto.getId() == null) {
             throw new IllegalArgumentException("Invalid cursor data");

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/controller/docs/BackupDocs.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/controller/docs/BackupDocs.java
@@ -1,6 +1,7 @@
 package com.sprint.example.sb01part2hrbankteam10.controller.docs;
 
 import com.sprint.example.sb01part2hrbankteam10.dto.BackupDto;
+import com.sprint.example.sb01part2hrbankteam10.dto.CursorPageResponseBackupDto;
 import com.sprint.example.sb01part2hrbankteam10.entity.Backup;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -60,7 +61,7 @@ public interface BackupDocs {
                     content = @Content(examples = @ExampleObject(value = "{ 'error': '담당자에게 문의해주세요.' }")))
     })
     @GetMapping
-    ResponseEntity<Map<String, Object>> getBackupList(
+    ResponseEntity<CursorPageResponseBackupDto> getBackupList(
             @Parameter(description = "작업자", example = "192.168.0.1")
             @RequestParam(required = false) String worker,
 

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/controller/docs/BackupDocs.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/controller/docs/BackupDocs.java
@@ -14,9 +14,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 
 @Tag(name = "Backup", description = "백업 관리 API")
@@ -69,10 +70,13 @@ public interface BackupDocs {
             @RequestParam(required = false) Backup.BackupStatus status,
 
             @Parameter(description = "시작 시간(부터)", example = "2023-01-01T12:00:00Z")
-            @RequestParam(required = false) LocalDateTime startedAtFrom,
+            @RequestParam(required = false) String startedAtFrom,
 
             @Parameter(description = "시작 시간(까지)", example = "2024-12-31T23:59:59")
-            @RequestParam(required = false) LocalDateTime startedAtTo,
+            @RequestParam(required = false) String startedAtTo,
+
+            @Parameter(description = "백업 파일", example = "40")
+            @RequestParam(required = false) Integer fileId,
 
             @Parameter(description = "이전 페이지 마지막 요소 ID")
             @RequestParam(required = false) Integer idAfter,

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/dto/BackupDto.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/dto/BackupDto.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class BackupDto {
   Integer id;
-  String workerIpAddress;
+  String worker;
   LocalDateTime startedAt;
   LocalDateTime endedAt;
   BackupStatus status;

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/dto/CursorPageResponseBackupDto.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/dto/CursorPageResponseBackupDto.java
@@ -1,0 +1,21 @@
+package com.sprint.example.sb01part2hrbankteam10.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CursorPageResponseBackupDto {
+    List<BackupDto> content;
+    String nextCursor;
+    Integer nextIdAfter;
+    Integer size;
+    Integer totalElements;
+    boolean hasNext;
+}

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/mapper/BackupMapper.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/mapper/BackupMapper.java
@@ -10,7 +10,7 @@ public class BackupMapper {
 
         return BackupDto.builder()
                 .id(backup.getId())
-                .workerIpAddress(backup.getWorkerIpAddress())
+                .worker(backup.getWorkerIpAddress())
                 .startedAt(backup.getStartedAt())
                 .endedAt(backup.getEndedAt())
                 .status(backup.getStatus())

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/service/BackupService.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/service/BackupService.java
@@ -13,6 +13,7 @@ public interface BackupService {
                                Backup.BackupStatus status,
                                LocalDateTime startedAtFrom,
                                LocalDateTime startedAtTo,
+                               Integer fileId,
                                Integer idAfter,
                                String cursor,
                                int size,

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/service/impl/BackupServiceImpl.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/service/impl/BackupServiceImpl.java
@@ -148,16 +148,13 @@ public class BackupServiceImpl implements BackupService {
   // 백업 여부 결정 로직: 가장 최근 완료된 배치 작업시간 < 직원 데이터 변경 시간 -> 백업 필요
   private boolean isBackupNeeded() {
 
-    String dataString = "2025-03-11T00:00:00";
-    LocalDateTime lastBackupTime = LocalDateTime.parse(dataString);
-//    LocalDateTime lastBackupTime = backupRepository.findLastCompletedBackupAt();
+    LocalDateTime lastBackupTime = backupRepository.findLastCompletedBackupAt();
 
     if (lastBackupTime == null) {
       lastBackupTime = LocalDateTime.MIN;
     }
-    String dataString2 = "2025-03-12T00:00:00";
-    LocalDateTime lastEmployeeUpdate = LocalDateTime.parse(dataString2);
-//    LocalDateTime lastEmployeeUpdate = employeeHistoryRepository.findLastModifiedAt();
+
+    LocalDateTime lastEmployeeUpdate = employeeHistoryRepository.findLastModifiedAt();
     if (lastEmployeeUpdate == null) {
       lastEmployeeUpdate = LocalDateTime.MIN;
     }

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/service/impl/BackupServiceImpl.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/service/impl/BackupServiceImpl.java
@@ -37,11 +37,10 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.apache.commons.lang3.StringEscapeUtils.escapeCsv;
 
@@ -60,7 +59,7 @@ public class BackupServiceImpl implements BackupService {
   @Override
   public Integer performBackup() {
 
-    String workerIpAddress = "SYSTEM";
+    String workerIpAddress = "system";
 
     // 로직: if 백업 불필요 -> 건너뜀 상태로 배치이력 저장하고 프로세스 종료
     if (!isBackupNeeded()) {
@@ -80,7 +79,7 @@ public class BackupServiceImpl implements BackupService {
       List<EmployeeForBackupDto> backupContent = fetchEmployeeData();
 
       // 전체 직원 정보를 CSV 파일로 저장 = 스트리밍/버퍼
-      ResponseEntity<Resource> response = convertBackupToCsvFile(backupContent);
+      ResponseEntity<Resource> response = convertBackupToCsvFile(backupContent, atStartBackupHistory.getId());
 
       // 파일을 MultipartFile로 변환 (파일이 생성되었을 경우만)
       if (response.getBody() instanceof FileSystemResource) {
@@ -117,8 +116,7 @@ public class BackupServiceImpl implements BackupService {
       fileStorage.saveBackup(fileId, backUpMultipartFile);
 
       // 백업 성공 -> 백업이력 완료로 수정
-      Backup completedBackupHistory = createBackupHistory(workerIpAddress, BackupStatus.COMPLETED,
-              atStartBackupHistory.getStartedAt(), LocalDateTime.now(), savedFile);
+      Backup completedBackupHistory = updateBackupHistory(atStartBackupHistory, workerIpAddress, savedFile);
       return backupRepository.save(completedBackupHistory).getId();
 
     } catch (Exception e) {
@@ -177,14 +175,27 @@ public class BackupServiceImpl implements BackupService {
             .build();
   }
 
-  private ResponseEntity<Resource> convertBackupToCsvFile(List<EmployeeForBackupDto> backupContent) {
+  private Backup updateBackupHistory(Backup backupHistory, String workerIpAddress, com.sprint.example.sb01part2hrbankteam10.entity.File savedFile) {
+    backupRepository.delete(backupHistory);
+    return createBackupHistory(workerIpAddress, BackupStatus.COMPLETED,
+            backupHistory.getStartedAt(), LocalDateTime.now(), savedFile);
+  }
+
+
+  private ResponseEntity<Resource> convertBackupToCsvFile(List<EmployeeForBackupDto> backupContent, Integer backupId) {
     File csvFile = null;
+    File zipFile = null;
+
     try {
       // 임시 디렉토리에 파일 생성
       csvFile = File.createTempFile("backup_", ".csv");
 
       try (BufferedWriter writer = new BufferedWriter(
               new OutputStreamWriter(new FileOutputStream(csvFile), StandardCharsets.UTF_8))) {
+
+        // BOM 마커 추가 (UTF-8 인코딩 명시)
+        writer.write('\uFEFF');
+
         // 헤더 작성
         writer.write("ID,직원번호,이름,이메일,부서,직급,입사일,상태");
         writer.newLine();
@@ -218,19 +229,41 @@ public class BackupServiceImpl implements BackupService {
         }
         writer.flush();
 
-        // 파일을 Resource로 변환
-        FileSystemResource resource = new FileSystemResource(csvFile);
+        // ZIP 파일 생성
+        zipFile = File.createTempFile("backup_", ".zip");
+        try (FileOutputStream fos = new FileOutputStream(zipFile);
+             ZipOutputStream zos = new ZipOutputStream(fos)) {
 
-        // ResponseEntity 생성
+          // ZIP 엔트리 생성 및 CSV 파일 추가
+          ZipEntry zipEntry = new ZipEntry("backup_" + backupId + ".csv");
+          zos.putNextEntry(zipEntry);
+
+          // 버퍼를 사용해 파일 내용 복사
+          byte[] buffer = new byte[1024];
+          try (FileInputStream fis = new FileInputStream(csvFile)) {
+            int length;
+            while ((length = fis.read(buffer)) > 0) {
+              zos.write(buffer, 0, length);
+            }
+          }
+          zos.closeEntry();
+        }
+
+        // 임시 CSV 파일 삭제
+        csvFile.delete();
+
+        // ZIP 파일 반환
+        FileSystemResource resource = new FileSystemResource(zipFile);
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=backup.csv")
-                .contentType(MediaType.parseMediaType("text/csv;charset=UTF-8"))
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"backup_" + backupId + ".zip\"")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .body(resource);
       }
     } catch (IOException e) {
-      if (csvFile != null && csvFile.exists()) {
-        csvFile.delete();
-      }
+      // 오류 발생 시 임시 파일 정리
+      if (csvFile != null && csvFile.exists()) csvFile.delete();
+      if (zipFile != null && zipFile.exists()) zipFile.delete();
       throw new RestApiException(BackupErrorCode.BACKUP_FILE_CREATION_FAILED, e.getMessage());
     }
   }
@@ -247,6 +280,7 @@ public class BackupServiceImpl implements BackupService {
 
   private MultipartFile logError(Exception e) {
     File logFile = new File("backup_error.log");
+    File zipFile = new File("backup_error.zip");
 
     try (FileWriter fileWriter = new FileWriter(logFile, true);
          BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)) {
@@ -258,14 +292,33 @@ public class BackupServiceImpl implements BackupService {
     }
 
     if (logFile.exists()) {
+      try (FileOutputStream fos = new FileOutputStream(zipFile);
+           ZipOutputStream zos = new ZipOutputStream(fos);
+           FileInputStream fis = new FileInputStream(logFile)) {
+
+        ZipEntry zipEntry = new ZipEntry(logFile.getName());
+        zos.putNextEntry(zipEntry);
+
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = fis.read(buffer)) > 0) {
+          zos.write(buffer, 0, length);
+        }
+
+        zos.closeEntry();
+      } catch (IOException ioException) {
+        ioException.printStackTrace();
+      }
+
+      // ZIP 파일을 MultipartFile로 변환
       try {
-        // File을 MultipartFile로 변환하는 방법
         MultipartFile multipartFile = new MockMultipartFile(
-                logFile.getName(),                // 파일 이름
-                logFile.getName(),                // 원본 파일 이름
-                "text/plain",                     // MIME 타입
-                new FileInputStream(logFile)      // 파일 내용
+                zipFile.getName(),
+                zipFile.getName(),
+                "application/zip",
+                new FileInputStream(zipFile)
         );
+
 
         // 파일 DB에 저장
         BigInteger fileSize = BigInteger.valueOf(logFile.length());
@@ -279,6 +332,10 @@ public class BackupServiceImpl implements BackupService {
 
         // 변환된 MultipartFile을 사용하여 저장
         fileStorage.saveBackup(fileId, multipartFile);
+
+        // 로그 파일 삭제
+        logFile.delete();
+
         return multipartFile;
 
       } catch (IOException ioException) {
@@ -328,6 +385,7 @@ public class BackupServiceImpl implements BackupService {
           Backup.BackupStatus status,
           LocalDateTime startedAtFrom,
           LocalDateTime startedAtTo,
+          Integer fileId,
           Integer idAfter,
           String cursor,
           int size,
@@ -354,6 +412,7 @@ public class BackupServiceImpl implements BackupService {
     // Specification 생성
     Specification<Backup> spec = Specification.where(null);
 
+    // 검색 조건으로 조회
     if (workerIpAddress != null) {
       spec = spec.and((root, query, cb) -> cb.equal(root.get("workerIpAddress"), workerIpAddress));
     }
@@ -362,8 +421,12 @@ public class BackupServiceImpl implements BackupService {
       spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), status));
     }
 
-    if (startedAtFrom != null && startedAtTo != null) {
-      spec = spec.and((root, query, cb) -> cb.between(root.get("startedAt"), startedAtFrom, startedAtTo));
+    if (startedAtFrom != null) {
+      spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get("startedAt"), startedAtFrom));
+    }
+
+    if (startedAtTo != null) {
+      spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get("startedAt"), startedAtTo));
     }
 
     if (idAfter != null) {
@@ -376,11 +439,12 @@ public class BackupServiceImpl implements BackupService {
       sort = Sort.by(sortDirection, "startedAt");
     } else if ("id".equals(sortField)) {
       sort = Sort.by(sortDirection, "id");
+    } else if ("endedAt".equals(sortField)) {
+      sort = Sort.by(sortDirection, "endedAt");
     } else {
       // 기본 정렬
       sort = Sort.by(Sort.Direction.DESC, "startedAt");
     }
-
     // 페이징 설정
     Pageable pageable = PageRequest.of(basePageable.getPageNumber(), basePageable.getPageSize(), sort);
 
@@ -390,10 +454,11 @@ public class BackupServiceImpl implements BackupService {
     // DTO 변환 로직
     return backupPage.map(backup -> BackupDto.builder()
             .id(backup.getId())
-            .workerIpAddress(backup.getWorkerIpAddress())
+            .worker(backup.getWorkerIpAddress())
             .status(backup.getStatus())
             .startedAt(backup.getStartedAt())
+            .endedAt(backup.getEndedAt())
+            .fileId(Optional.ofNullable(backup.getFile()).map(file -> file.getId()).orElse(null))
             .build());
   }
-
 }


### PR DESCRIPTION
### JIRA (jira의 이슈 키 값을 명시해주세요)
- OPS-141
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/OPS-141-backup-프론트-연결-수정 -> dev

### 변경 사항
- [x]  종료 시간 안뜸
- [x]  파일 다운로드 버튼 안 뜸
- [x]  파일 다운로드 하면 올바르지 않은 파일이라 뜸
- [x]  시작시간 From, To 설정하면 에러창 뜸
- [x] BackupDocs에 fileId 필드 추가
![image](https://github.com/user-attachments/assets/8ce976a8-e67a-43be-80f5-0dbfc97cc54e)

### 테스트 결과 (api 테스트 결과를 포함해주세요.)
![image](https://github.com/user-attachments/assets/9a77fce4-992d-40ef-9b1a-23b8a04edc86)
- 참고로 백업 아이디 2씩 차이나는 이유는 백업 이력 추가 로직에 백업을 시작하면 '진행중' 이력을 추가했다가 백업이 실패/완료되면 해당 이력이 업데이트 돼서 '진행중'이력은 삭제되는 방식이라 그렇습니다. 기존에는 실패/완료되어도 진행중 이력 삭제안해서 2개씩 추가됐던 거 이번에 수정했습니다.
- 다운받았을 때 파일번호랑 백업 아이디 1 차이나는건 필요하다면 수정해보겠습니다. 그런데 아이디가 곧 경로라 수정이 안될 것 같은 !
![image](https://github.com/user-attachments/assets/c87bad39-427e-4056-8dfe-8a5edf6ff391)
- [x] employeeHistory 로직으로 백업 잘되나 테스트 : 직원 정보 수정하고 처음 백업은 '완료', 두번째 백업은 '건너뜀'
![image](https://github.com/user-attachments/assets/a079bd12-04bb-4c7b-bf78-48dabf6f8bc8)

