### PR TITLE
Fix/ops 143 backup 정렬 이력등록 수정

### DIFF
--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/Backup.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/entity/Backup.java
@@ -52,6 +52,12 @@ public class Backup {
     this.status = status;
   }
 
+  public void updateStatus(BackupStatus status, LocalDateTime endedAt, BinaryContent binaryContent) {
+    this.status = status;
+    this.endedAt = endedAt;
+    this.binaryContent = binaryContent;
+  }
+
   public enum BackupStatus {
     IN_PROGRESS,
     COMPLETED,

--- a/src/main/java/com/sprint/example/sb01part2hrbankteam10/service/impl/BackupServiceImpl.java
+++ b/src/main/java/com/sprint/example/sb01part2hrbankteam10/service/impl/BackupServiceImpl.java
@@ -435,15 +435,20 @@ public class BackupServiceImpl implements BackupService {
     // 정렬 설정
     Sort sort;
     if ("startedAt".equals(sortField)) {
-      sort = Sort.by(sortDirection, "startedAt");
+      // 시작 시간 기준 정렬 시, 시작 시간이 null인 경우 ID로 정렬
+      // ID 정렬 방향도 주 정렬 방향과 동일하게 설정
+      sort = Sort.by(sortDirection, "startedAt").and(Sort.by(sortDirection, "id"));
     } else if ("id".equals(sortField)) {
       sort = Sort.by(sortDirection, "id");
     } else if ("endedAt".equals(sortField)) {
-      sort = Sort.by(sortDirection, "endedAt");
+      // 종료 시간 기준 정렬 시, 종료 시간이 null인 경우 ID로 정렬
+      // ID 정렬 방향도 주 정렬 방향과 동일하게 설정
+      sort = Sort.by(sortDirection, "endedAt").and(Sort.by(sortDirection, "id"));
     } else {
-      // 기본 정렬
-      sort = Sort.by(Sort.Direction.DESC, "startedAt");
+      // 기본 정렬: 시작 시간 내림차순, 시작 시간이 null인 경우 ID도 내림차순
+      sort = Sort.by(Sort.Direction.DESC, "startedAt").and(Sort.by(Sort.Direction.DESC, "id"));
     }
+
     // 페이징 설정
     Pageable pageable = PageRequest.of(basePageable.getPageNumber(), basePageable.getPageSize(), sort);
 


### PR DESCRIPTION
### JIRA (jira의 이슈 키 값을 명시해주세요)
- OPS-143

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/OPS-143-backup-정렬-이력등록-수정 -> dev

### 변경 사항
- 정렬 수정
- 백업 이력 '진행중' -> 완료 / 실패 시 이력 수정을 setter로 하고 @Transactional Dirty Checking 이용으로 수정 -> 백업 조회에서 ID값 2차이 나던거 원래대로 1차이로 해결

### 테스트 결과 (api 테스트 결과를 포함해주세요.)
![image](https://github.com/user-attachments/assets/14730b6a-d598-4cba-a55e-5575c8b929e8)
